### PR TITLE
Change field type to email

### DIFF
--- a/pages/07.contact/modular_alt.md
+++ b/pages/07.contact/modular_alt.md
@@ -22,7 +22,7 @@ form:
           classes: form-control form-control-lg
           label: Email
           placeholder: Enter your email address
-          type: text
+          type: email
           validate:
             rule: email
             required: true


### PR DESCRIPTION
This skeleton is referenced from the documentation at
https://learn.getgrav.org/forms/forms/how-to-forms-in-modular-pages.
However the validation of the email address does not work. This can be
seen at http://demo.getgrav.org/deliver-skeleton/contact. By just adding
"a" as mail address.

Thanks @flaviocopes for the support.
