### PR TITLE
Update contact form modular_alt.md

### DIFF
--- a/pages/07.contact/modular_alt.md
+++ b/pages/07.contact/modular_alt.md
@@ -39,7 +39,7 @@ form:
     buttons:
         - type: submit
           value: Submit
-          class: btn btn-primary btn-block
+          classes: btn btn-primary btn-block
 
     process:
         - email:


### PR DESCRIPTION
The current version of form plugin (v2.0.6 ) uses 'classes' instead of 'class' for buttons.